### PR TITLE
4097 수익

### DIFF
--- a/boj/수익.cpp
+++ b/boj/수익.cpp
@@ -1,0 +1,33 @@
+#include <iostream>
+#include <string>
+#include <vector>
+#include <algorithm>
+#include <queue>
+#include <stack>
+#include <regex>
+#include <map>
+#include <memory.h>
+using namespace std;
+int n;
+int main() {
+	ios::sync_with_stdio(false); cin.tie(NULL);
+	while (1) {
+		cin >> n;
+		if (n == 0)break;
+
+		int sum = 0;
+		int ans = -987654321;
+		for (int i = 0; i < n; i++) {
+			int num;
+			cin >> num;
+			if (sum + num > num) {
+				sum += num;
+			}
+			else {
+				sum = num;
+			}
+			ans = max(ans, sum);
+		}
+		cout << ans << '\n';
+	}
+}


### PR DESCRIPTION
# 문제
- close #6 
- https://www.acmicpc.net/problem/4097

# 풀이 후기

분류가 dp이길래 누적합을 이용한 dp 점화식을 구해서 풀었지만 50%에서 시간초과가 났다.
다른 사람의 풀이를 통해 해결했다. sum에 특정 날짜의 수익을 더한 값 vs 특정 날짜의 수익 을 비교해서 sum을 갱신한다.
sum을 업데이트하면 head를 갱신하는 것과 같다.